### PR TITLE
add workflows for deployments

### DIFF
--- a/.github/workflows/client-deploy.yml
+++ b/.github/workflows/client-deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy Frontend to Heroku
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "client/**"
+      - ".github/workflows/client-deploy.yml"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Add frontend remote origin
+        run: git remote add lesson-plans-frontend https://heroku:${{ secrets.HEROKU_API_TOKEN }}@git.heroku.com/${{ secrets.HEROKU_FRONTEND_APP_NAME  }}.git
+      
+      - name: Deploy frontend to Heroku
+        run: git push lesson-plans-frontend `git subtree split --prefix client main`:refs/heads/main --force

--- a/.github/workflows/server-deploy.yml
+++ b/.github/workflows/server-deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy Server to Heroku
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "server/**"
+      - ".github/workflows/server-deploy.yml"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Add server remote origin
+        run: git remote add lesson-plans-backend https://heroku:${{ secrets.HEROKU_API_TOKEN }}@git.heroku.com/${{ secrets.HEROKU_BACKEND_APP_NAME }}.git
+      
+      - name: Deploy server to Heroku
+        run: git push lesson-plans-backend `git subtree split --prefix server main`:refs/heads/main --force

--- a/server/Procfile
+++ b/server/Procfile
@@ -1,0 +1,1 @@
+worker: npm start:prod

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,9 @@
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {
-    "start": "concurrently \"nodemon src/index.ts\""
+    "postinstall": "tsc --project ./",
+    "start": "concurrently \"nodemon src/index.ts\"",
+    "start:prod": "node dist/index.js"
   },
   "dependencies": {
     "dotenv": "^16.0.1",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,12 +5,12 @@ import express, { Express, Request, Response } from 'express';
 
 // instantiate express app
 const app: Express = express();
-const port = process.env.SERVER_PORT || 4000;
+const port = process.env.PORT || 4000;
 
 app.get('/', (_req: Request, res: Response) => {
   res.send('Express and Typescript working!');
 });
 
 app.listen(port, () => {
-  console.log(`[server]: Server is running at https://localhost:${port}`);
+  console.log(`Server is running at http://localhost:${port}`);
 });

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -24,5 +24,5 @@
     "baseUrl": "."
   },
   "exclude": ["node_modules"],
-  "include": ["./src/**/*.ts", "src/index.ts"]
+  "include": ["./src/**/*.ts"]
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -24,5 +24,5 @@
     "baseUrl": "."
   },
   "exclude": ["node_modules"],
-  "include": ["./src/**/*.ts"]
+  "include": ["./src/**/*.ts", "src/index.ts"]
 }


### PR DESCRIPTION
Before merged, we need to insert these secrets in the repo settings
- `HEROKU_API_TOKEN`
- `HEROKU_FRONTEND_APP_NAME` 
- `HEROKU_BACKEND_APP_NAME`

## `HEROKU_API_TOKEN`
- API key for the heroku account (account that will create and keep these projects)

## `HEROKU_FRONTEND_APP_NAME` 
- Create an empty project for frontend in the account and give it a name. The name would be value for `HEROKU_FRONTEND_APP_NAME` 

## `HEROKU_BACKEND_APP_NAME`
- Create another empty project for backend in the account and give it a name. The name would be value for `HEROKU_BACKEND_APP_NAME`

** since we are using a free version of Heroku, we cannot run some workflow jobs simultaneously. We might have to re-run the jobs whenever the workflows intends to run simultaneously.